### PR TITLE
--save-dev instead of --save as loading grunt tasks is a dev task

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -31,7 +31,7 @@ require('load-grunt-tasks')(grunt);
 
 ## Install
 
-Install with [npm](https://npmjs.org/package/load-grunt-tasks): `npm install --save load-grunt-tasks`
+Install with [npm](https://npmjs.org/package/load-grunt-tasks): `npm install --save-dev load-grunt-tasks`
 
 
 ## Example


### PR DESCRIPTION
heya, load-grunt-tasks as devDependency? How about it... came to this conclusion and works in at least three projects. Works. 

Thanks for making our Gruntfiles cleaner!
