### PR TITLE
Shouldn't load `grunt-cli`

### DIFF
--- a/load-grunt-tasks.js
+++ b/load-grunt-tasks.js
@@ -13,6 +13,9 @@ module.exports = function (grunt, patterns, pkg) {
 		patterns = [patterns];
 	}
 
+	// Always ignore `grunt-cli`
+	patterns.push('!grunt-cli');
+
 	if (typeof pkg !== 'object') {
 		pkg = require(path.resolve(process.cwd(), 'package.json'));
 	}


### PR DESCRIPTION
Had a bug over at BBB where grunt-cli was defined as a dev deps for Travis-CI. I know we can install grunt-cli elsewhere in Travis, but that seemed like a common pattern, so maybe it's best if `load-grunt-task` simply ignores it and prevent this issue.
