### PR TITLE
Fix pattern matching and load non-dev deps

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,6 +1,6 @@
 'use strict';
 module.exports = function (grunt) {
-	require('./load-grunt-tasks')(grunt, ['grunt-*'], require('./package'));
+	require('./load-grunt-tasks')(grunt, 'grunt-*', require('./package'));
 
 	grunt.initConfig({
 		svgmin: {

--- a/readme.md
+++ b/readme.md
@@ -4,7 +4,7 @@
 
 Usually you would have to load each task one by one, which is unnecessarily cumbersome.
 
-This module will read the `devDependencies` in your package.json and load the tasks that matches your patterns.
+This module will read the `dependencies` and `devDependencies` in your package.json and load the tasks that matches your patterns.
 
 
 #### Before
@@ -49,7 +49,7 @@ module.exports = function (grunt) {
 
 By default `grunt-*` will be used as the [globbing pattern](https://github.com/isaacs/minimatch).
 
-You can optionally specify a pattern or an array of patterns:
+You can optionally specify a pattern:
 
 ```js
 require('load-grunt-tasks')(grunt, 'grunt-shell');
@@ -59,16 +59,17 @@ require('load-grunt-tasks')(grunt, 'grunt-shell');
 require('load-grunt-tasks')(grunt, 'grunt-contrib-*');
 ```
 
-```js
-require('load-grunt-tasks')(grunt, ['grunt-contrib-*', 'grunt-shell']);
-```
-
 You also have the option to specify the package.json as an object if it's not in the same folder as your Gruntfile:
 
 ```js
 require('load-grunt-tasks')(grunt, 'grunt-shell', require('../package'));
 ```
 
+If you want to blacklist a certain list of packages, you can list them as fourth parameter:
+
+```js
+require('load-grunt-tasks')(grunt, 'grunt-*', require('../package'), ['grunt-concurrent']);
+```
 
 ## License
 


### PR DESCRIPTION
- Fixes #7: Also load dependencies, not only devDependencies
- There used to be an issue with how globbing works. Because there was a map
  over all patterns and the result was combined, negative pattern matching had
  the opposite effect by default would load _all_ dev dependencies, completely
  ignoring the pattern. I removed the ability to provide multiple patterns,
  because there's no trivial way to make this work with minimatch. Instead,
  there is now a fourth (_shrugs_) argument to explicitly blacklist packages,
  which always includes 'grunt' and 'grunt-cli'.
