### PR TITLE
Version bump.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "load-grunt-tasks",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Load multiple grunt tasks using globbing patterns",
   "keywords": [
     "grunt",


### PR DESCRIPTION
Having ignored local `grunt`/`grunt-cli` modules would be useful for a team I am currently working with.
