### PR TITLE
fixes #5: filtering tasks with pattern `!`

### DIFF
--- a/load-grunt-tasks.js
+++ b/load-grunt-tasks.js
@@ -32,7 +32,7 @@ module.exports = function (grunt, patterns, pkg) {
     }).flatten().uniq().value();
   }
 
-  var tasks = _.difference(match(patterns), match(excludes)).pull('grunt', 'grunt-cli');
+  var tasks = _.chain(match(patterns)).difference(match(excludes)).pull('grunt', 'grunt-cli');
 
   _(tasks).forEach(grunt.loadNpmTasks);
 };


### PR DESCRIPTION
This should fix the problem in #5 where tasks could not be filtered from the list of matches.

```
require('load-grunt-tasks')(grunt, ['grunt-*', '!grunt-template-*']);
```

will now exclude any grunt-template modules from being loaded as tasks.
