### PR TITLE
Option 'config' does not work correctly when type is string.

### DIFF
--- a/load-grunt-tasks.js
+++ b/load-grunt-tasks.js
@@ -1,6 +1,7 @@
 'use strict';
 var globule = require('globule');
 var findup = require('findup-sync');
+var path = require('path');
 
 function arrayify(el) {
 	return Array.isArray(el) ? el : [el];
@@ -14,7 +15,7 @@ module.exports = function (grunt, options) {
 	var scope = arrayify(options.scope || ['dependencies', 'devDependencies', 'peerDependencies']);
 
 	if (typeof config === 'string') {
-		config = require(config);
+		config = require(path.resolve(config));
 	}
 
 	pattern.push('!grunt', '!grunt-cli');


### PR DESCRIPTION
Hi. When the type of config option is string, like `config: './package.json'`, grunt shows this following message.
Therefore, I fix it to load the path to be expected.

``` sh
>> Local Npm module "grunt-svgmin" not found. Is it installed?
```

Thanks.
