### PR TITLE
Use node_modules resolution algo

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@ var path = require('path');
 var pkgUp = require('pkg-up');
 var multimatch = require('multimatch');
 var arrify = require('arrify');
+var resolve = require('require-resolve');
 
 module.exports = function (grunt, opts) {
 	opts = opts || {};
@@ -22,5 +23,8 @@ module.exports = function (grunt, opts) {
 		return result.concat(Array.isArray(deps) ? deps : Object.keys(deps));
 	}, []);
 
-	multimatch(names, pattern).forEach(grunt.loadNpmTasks);
+	multimatch(names, pattern).forEach(function (pkgName) {
+		var resolved = resolve(path.join(pkgName, 'package.json'));
+		grunt.loadTasks(path.join(resolved.pkg.root, 'tasks'));
+	});
 };

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
   "dependencies": {
     "arrify": "^1.0.0",
     "multimatch": "^2.0.0",
-    "pkg-up": "^1.0.0"
+    "pkg-up": "^1.0.0",
+    "require-resolve": "0.0.2"
   },
   "devDependencies": {
     "grunt": "^0.4.2",


### PR DESCRIPTION
Hello!

Our codebase at work has folders that are packages (aka they have a package.json), but we put all dependencies in the project root's node_modules folder to keep them consolidated and to make dependency management easier.

load-grunt-tasks fails here, because it uses grunt's loadNpmTask method. That method, contrary to the convention put forth by node, only looks in the current directory's node_modules folder instead of recursing up the directory tree looking in each parents' node_modules folder.

This PR fixes that by resolving the package to an absolute path and then calling `loadTasks`.

While this is different behavior than loadNpmTask, I think it's much more useful and in line with node's default behavior. It's the same thing that would happen if a task were `require`d manually and passed into grunt.

Let me know what you think!