### PR TITLE
Fix requireResolution with not found task

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,7 +25,11 @@ module.exports = function (grunt, opts) {
 
 	multimatch(names, pattern).forEach(function (pkgName) {
 		if (opts.requireResolution === true) {
-			grunt.loadTasks(resolvePkg(path.join(pkgName, 'tasks')));
+			try {
+				grunt.loadTasks(resolvePkg(path.join(pkgName, 'tasks')));
+			} catch (e) {
+				grunt.log.error('Npm module "' + pkgName + '" not found. Is it installed?');
+			}
 		} else {
 			grunt.loadNpmTasks(pkgName);
 		}


### PR DESCRIPTION
Currently the `load-grunt-tasks` crashes when it's used together with the `requireResolution` and if the task can't be found.

The following error happens then:
```
Loading "Gruntfile.js" tasks...ERROR
>> TypeError: Arguments to path.join must be strings
```

With `try .. catch` around everything works fine.