### PR TITLE
A cwd option can be passed to the resolvePkg plugin to change where dependencies marked with requireResolution are loaded.

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,7 +26,7 @@ module.exports = function (grunt, opts) {
 	multimatch(names, pattern).forEach(function (pkgName) {
 		if (opts.requireResolution === true) {
 			try {
-				grunt.loadTasks(resolvePkg(path.join(pkgName, 'tasks')));
+				grunt.loadTasks(resolvePkg(path.join(pkgName, 'tasks'), { cwd: opts.requireResolutionCwd }));
 			} catch (err) {
 				grunt.log.error('npm package "' + pkgName + '" not found. Is it installed?');
 			}


### PR DESCRIPTION
I'm not sure if it is resolving this issue #47 correctly, but my usecase was close to him.

My gruntfile was inside a sub-module of my application and I wanted to load all grunt tasks from this submodule.

I had this inside my ```src/gruntfile.js``` and wanted to load dependencies from this module, but it was loading them from the parent module.
```javascript
    require('load-grunt-tasks')(grunt, {
        pattern: ['grunt-*'],
        config: path.join(__dirname, "../package.json"),
        requireResolution: true
    });
```

Now I have this and it loading my tasks correctly:
```javascript
    require('load-grunt-tasks')(grunt, {
        pattern: ['grunt-*'],
        config: path.join(__dirname, "../package.json"),
        requireResolution: true,
        requireResolutionCwd: __dirname
    });
```