### PR TITLE
Handle correctly scoped packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "load-grunt-tasks",
+  "name": "@lahautesociete/load-grunt-tasks",
   "version": "3.5.3",
   "description": "Load multiple grunt tasks using globbing patterns",
   "keywords": [
@@ -22,7 +22,7 @@
   "files": [
     "index.js"
   ],
-  "repository": "sindresorhus/load-grunt-tasks",
+  "repository": "la-haute-societe/load-grunt-tasks",
   "scripts": {
     "test": "xo && grunt"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "load-grunt-tasks",
-  "version": "3.5.2",
+  "version": "3.5.3",
   "description": "Load multiple grunt tasks using globbing patterns",
   "keywords": [
     "dependencies",
@@ -33,7 +33,7 @@
     "arrify": "^1.0.0",
     "multimatch": "^2.0.0",
     "pkg-up": "^1.0.0",
-    "resolve-pkg": "^0.1.0"
+    "resolve-pkg": "^1.0.0"
   },
   "devDependencies": {
     "grunt": "^1.0.1",


### PR DESCRIPTION
Fix #49 by bumping the version of resolve-pkg to `^1.0.0` in package.json