### PR TITLE
Print a useful error if package.json is missing

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,9 +11,9 @@ module.exports = (grunt, options = {}) => {
 
 	let cwd = process.cwd();
 	let config = options.config || pkgUp.sync();
-	if (['undefined', undefined, null].indexOf(config) > 0) {
-		console.error('ABORTED: package.json not found.\nPlease be sure to create a package.json and install all dependecies before run a grunt task.');
-		return false;
+
+	if (config === null) {
+		console.error('\u001B[41m%s\u001B[0m', 'ABORTED: package.json not found.\nPlease be sure to create a package.json and install all dependecies before run a grunt task.');
 	}
 
 	if (typeof config === 'string') {

--- a/index.js
+++ b/index.js
@@ -11,10 +11,11 @@ module.exports = (grunt, options = {}) => {
 
 	let cwd = process.cwd();
 	let config = options.config || pkgUp.sync();
-	if (['undefined', null].indexOf(config) > 0) {
-		console.error('\x1b[41m%s\x1b[0m', 'ABORTED: package.json not found.\nPlease be sure to create a package.json and install all dependecies before run a grunt task.');
+	if (['undefined', undefined, null].indexOf(config) > 0) {
+		console.error('ABORTED: package.json not found.\nPlease be sure to create a package.json and install all dependecies before run a grunt task.');
 		return false;
 	}
+
 	if (typeof config === 'string') {
 		const configPath = path.resolve(config);
 		cwd = path.dirname(configPath);

--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ module.exports = (grunt, options = {}) => {
 	let config = options.config || pkgUp.sync();
 
 	if (config === null) {
-		grunt.fail.fatal('package.json not found.\nPlease make sure to create a package.json and install all dependecies before run a grunt task.');
+		grunt.fail.fatal('package.json not found.\nPlease make sure to create a package.json and install all dependencies before you run Grunt.');
 	}
 
 	if (typeof config === 'string') {

--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ module.exports = (grunt, options = {}) => {
 	let config = options.config || pkgUp.sync();
 
 	if (config === null) {
-		grunt.fail.fatal('package.json not found.\nPlease make sure to create a package.json and install all dependencies before you run Grunt.');
+		grunt.fail.fatal('package.json not found. Make sure to create a package.json and install dependencies before you run Grunt.');
 	}
 
 	if (typeof config === 'string') {

--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ module.exports = (grunt, options = {}) => {
 	let config = options.config || pkgUp.sync();
 
 	if (config === null) {
-		console.error('\u001B[41m%s\u001B[0m', 'ABORTED: package.json not found.\nPlease be sure to create a package.json and install all dependecies before run a grunt task.');
+		grunt.fail.fatal('package.json not found.\nPlease make sure to create a package.json and install all dependecies before run a grunt task.');
 	}
 
 	if (typeof config === 'string') {

--- a/index.js
+++ b/index.js
@@ -11,6 +11,10 @@ module.exports = (grunt, options = {}) => {
 
 	let cwd = process.cwd();
 	let config = options.config || pkgUp.sync();
+	if (['undefined', null].indexOf(config) > 0) {
+		console.error('\x1b[41m%s\x1b[0m', 'ABORTED: package.json not found.\nPlease be sure to create a package.json and install all dependecies before run a grunt task.');
+		return false;
+	}
 	if (typeof config === 'string') {
 		const configPath = path.resolve(config);
 		cwd = path.dirname(configPath);

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
 		"resolve-pkg": "^2.0.0"
 	},
 	"devDependencies": {
-		"grunt": "^1.0.1",
+		"grunt": "^1.0.4",
 		"grunt-cli": "^1.2.0",
 		"grunt-svgmin": "^6.0.0",
 		"xo": "^0.24.0"

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
 		"resolve-pkg": "^2.0.0"
 	},
 	"devDependencies": {
-		"grunt": "^1.0.4",
+		"grunt": "^1.0.1",
 		"grunt-cli": "^1.2.0",
 		"grunt-svgmin": "^6.0.0",
 		"xo": "^0.24.0"


### PR DESCRIPTION
Hello!

This fixes [#60](https://issuehunt.io/repos/12143193/issues/60)

If I understand it right we need to check if the package.json is missing or not, like @kirbysayshi said it on the issue. 
In this case I made a small condition to check this `['undefined', null].indexOf(config) > 0`.

Let me know if there is more about this issue than this.


<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#60: Fail with descriptive error if package.json is missing](https://issuehunt.io/repos/12143193/issues/60)
---

IssueHunt has been backed by the following sponsors. [Become a sponsor](https://issuehunt.io/membership/members)
</details>
<!-- /Issuehunt content-->